### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
       runs-on: windows-latest
       steps:
       -  name: Checkout
-         uses: actions/checkout@v4
+         uses: actions/checkout@v6
       -  name: Set up JDK 21
-         uses: actions/setup-java@v4.2.2
+         uses: actions/setup-java@v5
          with:
             distribution: temurin
             java-version: 21
       -  name: Set up cache
-         uses: actions/cache@v4
+         uses: actions/cache@v5
          with:
            path: ~/.m2/repository
            key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Updated GitHub Action versions in `.github/workflows/build.yml` to their latest major versions. Specifically, updated actions/checkout to v6, actions/setup-java to v5, and actions/cache to v5. Verified the changes by running the project's build process.

---
*PR created automatically by Jules for task [15132847073695034503](https://jules.google.com/task/15132847073695034503) started by @RoiSoleil*